### PR TITLE
include <array> in simd_avx.h

### DIFF
--- a/src/simd_avx.h
+++ b/src/simd_avx.h
@@ -2,6 +2,7 @@
 #define SIMD_AVX_H
 
 #include <immintrin.h>
+#include <array>
 
 
 /*


### PR DESCRIPTION
fix missing include:
```
In file included from /Users/shirnschall/ASC-HPC/src/simd.h:245:
/Users/shirnschall/ASC-HPC/src/simd_avx.h:43:32: error: implicit instantiation of undefined template 'std::array<double, 4>'
    SIMD (std::array<double,4> a) : SIMD(a[0],a[1],a[2],a[3]) { }
```